### PR TITLE
Fix container validation and add regression test

### DIFF
--- a/src/BlobLaravel/AzureStorageBlobServiceProvider.php
+++ b/src/BlobLaravel/AzureStorageBlobServiceProvider.php
@@ -21,7 +21,7 @@ final class AzureStorageBlobServiceProvider extends ServiceProvider
                 throw new \InvalidArgumentException('The [connection_string] must be a string in the disk configuration.');
             }
 
-            if (! isset($config['container']) && ! is_string($config['container'])) {
+            if (! isset($config['container']) || ! is_string($config['container'])) {
                 throw new \InvalidArgumentException('The [container] must be a string in the disk configuration.');
             }
 

--- a/tests/BlobLaravel/AzureStorageBlobServiceProviderTest.php
+++ b/tests/BlobLaravel/AzureStorageBlobServiceProviderTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Tests\BlobLaravel;
+
+use AzureOss\Storage\BlobLaravel\AzureStorageBlobServiceProvider;
+use Illuminate\Support\Facades\Storage;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class AzureStorageBlobServiceProviderTest extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [AzureStorageBlobServiceProvider::class];
+    }
+
+    #[Test]
+    public function it_throws_when_container_is_missing(): void
+    {
+        /** @phpstan-ignore-next-line */
+        $this->app['config']->set('filesystems.disks.azure', [
+            'driver' => 'azure-storage-blob',
+            'connection_string' => 'UseDevelopmentStorage=true',
+        ]);
+
+        Storage::forgetDisk('azure');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [container] must be a string in the disk configuration.');
+
+        Storage::disk('azure');
+    }
+
+    #[Test]
+    public function it_throws_when_container_is_not_a_string(): void
+    {
+        /** @phpstan-ignore-next-line */
+        $this->app['config']->set('filesystems.disks.azure', [
+            'driver' => 'azure-storage-blob',
+            'connection_string' => 'UseDevelopmentStorage=true',
+            'container' => ['invalid'],
+        ]);
+
+        Storage::forgetDisk('azure');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The [container] must be a string in the disk configuration.');
+
+        Storage::disk('azure');
+    }
+}


### PR DESCRIPTION
This PR fixes the validation logic for the `container` configuration in the Laravel service provider and adds a regression test for it.

Previously, the validation used `&&`, which could allow invalid non-string values to bypass the check and could also evaluate an undefined key when `container` was missing.

This change replaces `&&` with `||` and adds test coverage for both missing and invalid `container` values.

This supersedes the earlier PR opened against the subtree split repository.
