### PR TITLE
Improve block blob uploads and auto-select transfer size

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,6 @@
          displayDetailsOnTestsThatTriggerWarnings="true">
     <php>
         <env name="AZURE_STORAGE_CONNECTION_STRING" value="UseDevelopmentStorage=true"/>
-        <env name="AZURE_STORAGE_CONTAINER" value="azureoss"/>
     </php>
 
     <testsuites>

--- a/src/Blob/BlobClient.php
+++ b/src/Blob/BlobClient.php
@@ -237,61 +237,48 @@ final class BlobClient
 
     private function uploadInSequentialBlocksAsync(StreamInterface $content, UploadBlobOptions $options): PromiseInterface
     {
-        $blockIds = [];
-        $contextMD5 = hash_init('md5');
+        $sequentialOptions = clone $options;
+        $sequentialOptions->maximumConcurrency = 1;
 
-        $putBlockRequestGenerator = function () use (&$content, &$options, &$blockIds, &$contextMD5): \Generator {
-            while (true) {
-                $blockContent = $content->read($options->maximumTransferSize);
-                if ($blockContent === '') {
-                    break;
-                }
-
-                $blockId = $this->getNextBlockId($blockIds);
-                $blockIds[] = $blockId;
-
-                hash_update($contextMD5, $blockContent);
-
-                yield fn () => $this->blockBlobClient->stageBlockAsync($blockId, $blockContent);
-            }
-        };
-
-        return (new Pool(
-            $this->client,
-            $putBlockRequestGenerator(),
-            ['concurrency' => 1],
-        ))
-            ->promise()
-            ->then(
-                function () use (&$blockIds, &$options, &$contextMD5) {
-                    if ($options->httpHeaders->contentHash === '') {
-                        $options->httpHeaders->contentHash = hash_final($contextMD5, true);
-                    }
-
-                    return $this->blockBlobClient->commitBlockListAsync(
-                        $blockIds,
-                        new CommitBlockListOptions(httpHeaders: $options->httpHeaders),
-                    );
-                },
-            );
+        return $this->uploadInParallelBlocksAsync($content, $sequentialOptions);
     }
 
     private function uploadInParallelBlocksAsync(StreamInterface $content, UploadBlobOptions $options): PromiseInterface
     {
         $blockIds = [];
+        $contextMD5 = $options->httpHeaders->contentHash === '' ? hash_init('md5') : null;
 
-        $putBlockRequestGenerator = function () use (&$content, &$options, &$blockIds): \Generator {
+        $putBlockRequestGenerator = function () use (&$content, &$options, &$blockIds, &$contextMD5): \Generator {
             while (true) {
                 $blockContent = StreamUtils::streamFor();
-                StreamUtils::copyToStream($content, $blockContent, $options->maximumTransferSize);
+                $remaining = $options->maximumTransferSize;
+
+                while ($remaining > 0 && ! $content->eof()) {
+                    $chunk = $content->read(min(8192, $remaining));
+                    if ($chunk === '') {
+                        break;
+                    }
+
+                    $remaining -= strlen($chunk);
+                    $blockContent->write($chunk);
+
+                    if ($contextMD5 !== null) {
+                        hash_update($contextMD5, $chunk);
+                    }
+                }
+
                 if ($blockContent->getSize() === 0) {
                     break;
+                }
+
+                if ($blockContent->isSeekable()) {
+                    $blockContent->rewind();
                 }
 
                 $blockId = $this->getNextBlockId($blockIds);
                 $blockIds[] = $blockId;
 
-                yield fn () => $this->blockBlobClient->stageBlock($blockId, $blockContent);
+                yield fn () => $this->blockBlobClient->stageBlockAsync($blockId, $blockContent);
             }
         };
 
@@ -304,9 +291,9 @@ final class BlobClient
         return $pool
             ->promise()
             ->then(
-                function () use (&$content, &$blockIds, &$options) {
-                    if ($options->httpHeaders->contentHash === '') {
-                        $options->httpHeaders->contentHash = StreamUtils::hash($content, 'md5', true);
+                function () use (&$blockIds, &$options, &$contextMD5) {
+                    if ($contextMD5 !== null && $options->httpHeaders->contentHash === '') {
+                        $options->httpHeaders->contentHash = hash_final($contextMD5, true);
                     }
 
                     return $this->blockBlobClient->commitBlockListAsync(

--- a/src/Blob/BlobClient.php
+++ b/src/Blob/BlobClient.php
@@ -292,13 +292,15 @@ final class BlobClient
             ->promise()
             ->then(
                 function () use (&$blockIds, &$options, &$contextMD5) {
-                    if ($contextMD5 !== null && $options->httpHeaders->contentHash === '') {
-                        $options->httpHeaders->contentHash = hash_final($contextMD5, true);
+                    $commitHeaders = clone $options->httpHeaders;
+
+                    if ($contextMD5 !== null && $commitHeaders->contentHash === '') {
+                        $commitHeaders->contentHash = hash_final($contextMD5, true);
                     }
 
                     return $this->blockBlobClient->commitBlockListAsync(
                         $blockIds,
-                        new CommitBlockListOptions(httpHeaders: $options->httpHeaders),
+                        new CommitBlockListOptions(httpHeaders: $commitHeaders),
                     );
                 },
             );

--- a/src/Blob/BlobClient.php
+++ b/src/Blob/BlobClient.php
@@ -213,16 +213,14 @@ final class BlobClient
 
         $content = StreamHelper::createUploadStream($content, $options->maximumTransferSize);
 
-        if ($content->getSize() === null || ! $content->isSeekable()) {
-            return $this->uploadInSequentialBlocksAsync($content, $options);
-        } elseif ($content->getSize() > $options->initialTransferSize) {
-            return $this->uploadInParallelBlocksAsync($content, $options);
+        if ($content->getSize() === null || $content->getSize() > $options->initialTransferSize) {
+            return $this->uploadViaBlockBlobAsync($content, $options);
         } else {
-            return $this->uploadSingleAsync($content, $options);
+            return $this->uploadViaPutBlobAsync($content, $options);
         }
     }
 
-    private function uploadSingleAsync(StreamInterface $content, UploadBlobOptions $options): PromiseInterface
+    private function uploadViaPutBlobAsync(StreamInterface $content, UploadBlobOptions $options): PromiseInterface
     {
         return $this->client
             ->putAsync($this->uri, [
@@ -235,15 +233,7 @@ final class BlobClient
             ]);
     }
 
-    private function uploadInSequentialBlocksAsync(StreamInterface $content, UploadBlobOptions $options): PromiseInterface
-    {
-        $sequentialOptions = clone $options;
-        $sequentialOptions->maximumConcurrency = 1;
-
-        return $this->uploadInParallelBlocksAsync($content, $sequentialOptions);
-    }
-
-    private function uploadInParallelBlocksAsync(StreamInterface $content, UploadBlobOptions $options): PromiseInterface
+    private function uploadViaBlockBlobAsync(StreamInterface $content, UploadBlobOptions $options): PromiseInterface
     {
         $blockIds = [];
         $contextMD5 = $options->httpHeaders->contentHash === '' ? hash_init('md5') : null;

--- a/src/Blob/BlobClient.php
+++ b/src/Blob/BlobClient.php
@@ -211,37 +211,43 @@ final class BlobClient
             $options = new UploadBlobOptions;
         }
 
-        $content = StreamHelper::createUploadStream($content, $options->maximumTransferSize);
+        $content = StreamHelper::createUploadStream($content, $options->maximumTransferSize ?? 8_000_000);
+        $maximumTransferSize = $this->resolveMaximumTransferSize($content, $options);
 
         if ($content->getSize() === null || $content->getSize() > $options->initialTransferSize) {
-            return $this->uploadViaBlockBlobAsync($content, $options);
+            return $this->uploadViaBlockBlobAsync(
+                $content,
+                $options->maximumConcurrency,
+                $maximumTransferSize,
+                $options->httpHeaders,
+            );
         } else {
-            return $this->uploadViaPutBlobAsync($content, $options);
+            return $this->uploadViaPutBlobAsync($content, $options->httpHeaders);
         }
     }
 
-    private function uploadViaPutBlobAsync(StreamInterface $content, UploadBlobOptions $options): PromiseInterface
+    private function uploadViaPutBlobAsync(StreamInterface $content, BlobHttpHeaders $httpHeaders): PromiseInterface
     {
         return $this->client
             ->putAsync($this->uri, [
                 RequestOptions::HEADERS => array_filter([
                     'x-ms-blob-type' => 'BlockBlob',
                     'Content-Length' => $content->getSize(),
-                    ...$options->httpHeaders->toArray(),
+                    ...$httpHeaders->toArray(),
                 ], fn ($value) => $value !== null),
                 RequestOptions::BODY => $content,
             ]);
     }
 
-    private function uploadViaBlockBlobAsync(StreamInterface $content, UploadBlobOptions $options): PromiseInterface
+    private function uploadViaBlockBlobAsync(StreamInterface $content, int $maximumConcurrency, int $maximumTransferSize, BlobHttpHeaders $httpHeaders): PromiseInterface
     {
         $blockIds = [];
-        $contextMD5 = $options->httpHeaders->contentHash === '' ? hash_init('md5') : null;
+        $contextMD5 = $httpHeaders->contentHash === '' ? hash_init('md5') : null;
 
-        $putBlockRequestGenerator = function () use (&$content, &$options, &$blockIds, &$contextMD5): \Generator {
+        $putBlockRequestGenerator = function () use (&$content, &$blockIds, &$contextMD5, $maximumTransferSize): \Generator {
             while (true) {
                 $blockContent = StreamUtils::streamFor();
-                $remaining = $options->maximumTransferSize;
+                $remaining = $maximumTransferSize;
 
                 while ($remaining > 0 && ! $content->eof()) {
                     $chunk = $content->read(min(8192, $remaining));
@@ -275,14 +281,14 @@ final class BlobClient
         $pool = new Pool(
             $this->client,
             $putBlockRequestGenerator(),
-            ['concurrency' => $options->maximumConcurrency],
+            ['concurrency' => $maximumConcurrency],
         );
 
         return $pool
             ->promise()
             ->then(
-                function () use (&$blockIds, &$options, &$contextMD5) {
-                    $commitHeaders = clone $options->httpHeaders;
+                function () use (&$blockIds, $httpHeaders, &$contextMD5) {
+                    $commitHeaders = clone $httpHeaders;
 
                     if ($contextMD5 !== null && $commitHeaders->contentHash === '') {
                         $commitHeaders->contentHash = hash_final($contextMD5, true);
@@ -294,6 +300,21 @@ final class BlobClient
                     );
                 },
             );
+    }
+
+    private function resolveMaximumTransferSize(StreamInterface $content, UploadBlobOptions $options): int
+    {
+        if ($options->maximumTransferSize !== null) {
+            return $options->maximumTransferSize;
+        }
+
+        $contentLength = $content->getSize();
+
+        if ($contentLength === null) {
+            return 8_000_000;
+        }
+
+        return max(8_000_000, (int) ceil($contentLength / 50_000));
     }
 
     /**

--- a/src/Blob/Models/UploadBlobOptions.php
+++ b/src/Blob/Models/UploadBlobOptions.php
@@ -10,14 +10,14 @@ final class UploadBlobOptions
 
     /**
      * @param  int  $initialTransferSize  The size of the first range request in bytes. Blobs smaller than this limit will be transferred in a single request. Blobs larger than this limit will continue being transferred in chunks of size MaximumTransferSize.
-     * @param  int  $maximumTransferSize  The maximum length of a transfer in bytes.
+     * @param  ?int  $maximumTransferSize  The maximum length of a transfer in bytes.
      * @param  int  $maximumConcurrency  The maximum number of workers that may be used in a parallel transfer.
      */
     public function __construct(
         public ?string $contentType = null,
         public int $initialTransferSize = 256_000_000,
-        public int $maximumTransferSize = 8_000_000,
-        public int $maximumConcurrency = 25,
+        public ?int $maximumTransferSize = null,
+        public int $maximumConcurrency = 5,
         ?BlobHttpHeaders $httpHeaders = null,
     ) {
         $this->httpHeaders = $httpHeaders ?? new BlobHttpHeaders;

--- a/tests/Blob/Feature/BlobClientTest.php
+++ b/tests/Blob/Feature/BlobClientTest.php
@@ -10,7 +10,6 @@ use AzureOss\Storage\Blob\Exceptions\CannotVerifyCopySourceException;
 use AzureOss\Storage\Blob\Exceptions\ContainerNotFoundException;
 use AzureOss\Storage\Blob\Exceptions\NoPendingCopyOperationException;
 use AzureOss\Storage\Blob\Exceptions\TagsTooLargeException;
-use AzureOss\Storage\Blob\Models\BlobHttpHeaders;
 use AzureOss\Storage\Blob\Models\CopyStatus;
 use AzureOss\Storage\Blob\Models\UploadBlobOptions;
 use AzureOss\Storage\Blob\Sas\BlobSasBuilder;
@@ -194,9 +193,27 @@ final class BlobClientTest extends TestCase
         self::assertEquals('text/plain', $properties->contentType);
         self::assertEquals(1000, $properties->contentLength);
 
-        $afterUploadContent = $blob->downloadStreaming()->content;
+        $afterUploadContent = $blob->downloadStreaming()->content->getContents();
 
         self::assertEquals($beforeUploadContent, $afterUploadContent);
+    }
+
+    #[Test]
+    public function upload_works_with_size_equal_to_initial_transfer_size(): void
+    {
+        $container = $this->tempContainer();
+        $blob = $container->getBlobClient('test');
+        $file = $this->tempFile(1000);
+
+        $beforeUploadContent = $file->getContents();
+        $file->rewind();
+
+        $blob->upload($file, new UploadBlobOptions('text/plain', initialTransferSize: 1000, maximumTransferSize: 100));
+
+        $result = $blob->downloadStreaming();
+
+        self::assertEquals($beforeUploadContent, $result->content->getContents());
+        self::assertEquals(1000, $result->properties->contentLength);
     }
 
     #[Test]
@@ -292,6 +309,7 @@ final class BlobClientTest extends TestCase
         self::assertEquals($beforeUploadContent, $result->content->getContents());
         self::assertEquals(md5($beforeUploadContent), $result->properties->contentMD5);
     }
+
 
     #[Test]
     public function upload_works_with_empty_file(): void

--- a/tests/Blob/Feature/BlobClientTest.php
+++ b/tests/Blob/Feature/BlobClientTest.php
@@ -10,6 +10,7 @@ use AzureOss\Storage\Blob\Exceptions\CannotVerifyCopySourceException;
 use AzureOss\Storage\Blob\Exceptions\ContainerNotFoundException;
 use AzureOss\Storage\Blob\Exceptions\NoPendingCopyOperationException;
 use AzureOss\Storage\Blob\Exceptions\TagsTooLargeException;
+use AzureOss\Storage\Blob\Models\BlobHttpHeaders;
 use AzureOss\Storage\Blob\Models\CopyStatus;
 use AzureOss\Storage\Blob\Models\UploadBlobOptions;
 use AzureOss\Storage\Blob\Sas\BlobSasBuilder;
@@ -309,7 +310,6 @@ final class BlobClientTest extends TestCase
         self::assertEquals($beforeUploadContent, $result->content->getContents());
         self::assertEquals(md5($beforeUploadContent), $result->properties->contentMD5);
     }
-
 
     #[Test]
     public function upload_works_with_empty_file(): void

--- a/tests/Blob/Feature/MockBlobClientTest.php
+++ b/tests/Blob/Feature/MockBlobClientTest.php
@@ -136,6 +136,36 @@ class MockBlobClientTest extends TestCase
     }
 
     #[Test]
+    public function upload_unknown_sized_stream_uses_default_block_size_when_not_provided(): void
+    {
+        Server::enqueue([
+            ...array_fill(0, 8, new Response(200)), // 7 chunks + 1 commit request
+            new Response(501),
+        ]);
+
+        $file = $this->tempFile(50_000_000);
+
+        $stream = new class($file) implements StreamInterface
+        {
+            use StreamDecoratorTrait;
+
+            public function getSize(): ?int
+            {
+                return null;
+            }
+        };
+
+        $this->blob->upload($stream, new UploadBlobOptions('text/plain', initialTransferSize: 0, maximumTransferSize: null));
+
+        $requests = Server::received();
+
+        self::assertCount(8, $requests);
+        self::assertSame('8000000', $requests[0]->getHeaderLine('Content-Length'));
+        parse_str($requests[7]->getUri()->getQuery(), $query);
+        self::assertSame('blocklist', $query['comp'] ?? null);
+    }
+
+    #[Test]
     public function upload_uses_single_upload_when_size_equals_initial_transfer_size(): void
     {
         Server::enqueue([
@@ -171,9 +201,10 @@ class MockBlobClientTest extends TestCase
         $this->blob->upload($stream, new UploadBlobOptions('text/plain', initialTransferSize: 0, maximumTransferSize: 5_000_000));
 
         $requests = Server::received();
+        $lastRequestIndex = count($requests) - 1;
 
         self::assertGreaterThan(1, count($requests));
-        parse_str($requests[array_key_last($requests)]->getUri()->getQuery(), $query);
+        parse_str($requests[$lastRequestIndex]->getUri()->getQuery(), $query);
         self::assertSame('blocklist', $query['comp'] ?? null);
     }
 
@@ -201,5 +232,108 @@ class MockBlobClientTest extends TestCase
 
         self::assertCount(2, $requests);
         self::assertSame(base64_encode($contentHash), $requests[1]->getHeaderLine('x-ms-blob-content-md5'));
+    }
+
+    #[Test]
+    public function upload_known_size_stream_automatically_calculates_block_size_when_not_provided(): void
+    {
+        Server::enqueue([
+            new Response(200),
+            new Response(200),
+            new Response(501),
+        ]);
+
+        $stream = new class implements StreamInterface
+        {
+            private int $remaining = 8_000_001;
+
+            public function __toString(): string
+            {
+                return '';
+            }
+
+            public function close(): void {}
+
+            public function detach()
+            {
+                return null;
+            }
+
+            public function getSize(): int
+            {
+                return 400_000_050_000;
+            }
+
+            public function tell(): int
+            {
+                return 8_000_001 - $this->remaining;
+            }
+
+            public function eof(): bool
+            {
+                return $this->remaining === 0;
+            }
+
+            public function isSeekable(): bool
+            {
+                return false;
+            }
+
+            public function seek($offset, $whence = SEEK_SET): void
+            {
+                throw new \RuntimeException('Not seekable.');
+            }
+
+            public function rewind(): void
+            {
+                throw new \RuntimeException('Not seekable.');
+            }
+
+            public function isWritable(): bool
+            {
+                return false;
+            }
+
+            public function write($string): int
+            {
+                throw new \RuntimeException('Not writable.');
+            }
+
+            public function isReadable(): bool
+            {
+                return true;
+            }
+
+            public function read($length): string
+            {
+                if ($this->remaining === 0) {
+                    return '';
+                }
+
+                $chunkLength = min($length, $this->remaining);
+                $this->remaining -= $chunkLength;
+
+                return str_repeat('a', $chunkLength);
+            }
+
+            public function getContents(): string
+            {
+                return $this->read($this->remaining);
+            }
+
+            public function getMetadata($key = null): mixed
+            {
+                return $key === null ? [] : null;
+            }
+        };
+
+        $this->blob->upload($stream, new UploadBlobOptions('text/plain', initialTransferSize: 0, maximumTransferSize: null));
+
+        $requests = Server::received();
+
+        self::assertCount(2, $requests);
+        self::assertSame('8000001', $requests[0]->getHeaderLine('Content-Length'));
+        parse_str($requests[1]->getUri()->getQuery(), $query);
+        self::assertSame('blocklist', $query['comp'] ?? null);
     }
 }

--- a/tests/Blob/Feature/MockBlobClientTest.php
+++ b/tests/Blob/Feature/MockBlobClientTest.php
@@ -6,6 +6,7 @@ namespace AzureOss\Storage\Tests\Blob\Feature;
 
 use AzureOss\Storage\Blob\BlobClient;
 use AzureOss\Storage\Blob\BlobServiceClient;
+use AzureOss\Storage\Blob\Models\BlobHttpHeaders;
 use AzureOss\Storage\Blob\Models\UploadBlobOptions;
 use AzureOss\Storage\Tests\CreatesTempFiles;
 use GuzzleHttp\Psr7\Response;
@@ -41,8 +42,6 @@ class MockBlobClientTest extends TestCase
     #[Test]
     public function upload_single_sends_correct_amount_of_requests(): void
     {
-        $this->expectNotToPerformAssertions();
-
         Server::enqueue([
             new Response(200), // only one request
             new Response(501), // fail if more requests
@@ -50,13 +49,17 @@ class MockBlobClientTest extends TestCase
 
         $file = $this->tempFile(1000);
         $this->blob->upload($file, new UploadBlobOptions('text/plain', initialTransferSize: 2000));
+
+        $requests = Server::received();
+
+        self::assertCount(1, $requests);
+        self::assertSame('', $requests[0]->getUri()->getQuery());
+        self::assertSame('BlockBlob', $requests[0]->getHeaderLine('x-ms-blob-type'));
     }
 
     #[Test]
     public function upload_parallel_blocks_sends_correct_amount_of_requests(): void
     {
-        $this->expectNotToPerformAssertions(); // should not throw because of the 501
-
         Server::enqueue([
             ...array_fill(0, 11, new Response(200)), // 10 chunks + 1 commit request
             new Response(501), // fail if more requests
@@ -64,13 +67,23 @@ class MockBlobClientTest extends TestCase
 
         $file = $this->tempFile(50_000_000);
         $this->blob->upload($file, new UploadBlobOptions('text/plain', initialTransferSize: 0, maximumTransferSize: 5_000_000));
+
+        $requests = Server::received();
+
+        self::assertCount(11, $requests);
+        foreach (array_slice($requests, 0, 10) as $request) {
+            parse_str($request->getUri()->getQuery(), $query);
+            self::assertSame('block', $query['comp'] ?? null);
+            self::assertArrayHasKey('blockid', $query);
+        }
+
+        parse_str($requests[10]->getUri()->getQuery(), $query);
+        self::assertSame('blocklist', $query['comp'] ?? null);
     }
 
     #[Test]
     public function upload_parallel_blocks_sends_correct_amount_of_requests_for_small_files(): void
     {
-        $this->expectNotToPerformAssertions(); // should not throw because of the 501
-
         Server::enqueue([
             ...array_fill(0, 2, new Response(200)), // 1 chunks + 1 commit request
             new Response(501), // fail if more requests
@@ -78,13 +91,19 @@ class MockBlobClientTest extends TestCase
 
         $file = $this->tempFile(50_000);
         $this->blob->upload($file, new UploadBlobOptions('text/plain', initialTransferSize: 0, maximumTransferSize: 8_000_000));
+
+        $requests = Server::received();
+
+        self::assertCount(2, $requests);
+        parse_str($requests[0]->getUri()->getQuery(), $firstQuery);
+        parse_str($requests[1]->getUri()->getQuery(), $secondQuery);
+        self::assertSame('block', $firstQuery['comp'] ?? null);
+        self::assertSame('blocklist', $secondQuery['comp'] ?? null);
     }
 
     #[Test]
-    public function upload_sequential_blocks_sends_correct_amount_of_requests(): void
+    public function upload_unknown_sized_stream_uses_block_upload_requests(): void
     {
-        $this->expectNotToPerformAssertions(); // should not throw because of the 501
-
         Server::enqueue([
             ...array_fill(0, 11, new Response(200)), // 10 chunks + 1 commit request
             new Response(501), // fail if more requests
@@ -103,13 +122,39 @@ class MockBlobClientTest extends TestCase
         };
 
         $this->blob->upload($stream, new UploadBlobOptions('text/plain', initialTransferSize: 0, maximumTransferSize: 5_000_000));
+
+        $requests = Server::received();
+
+        self::assertCount(11, $requests);
+        foreach (array_slice($requests, 0, 10) as $request) {
+            parse_str($request->getUri()->getQuery(), $query);
+            self::assertSame('block', $query['comp'] ?? null);
+        }
+
+        parse_str($requests[10]->getUri()->getQuery(), $query);
+        self::assertSame('blocklist', $query['comp'] ?? null);
+    }
+
+    #[Test]
+    public function upload_uses_single_upload_when_size_equals_initial_transfer_size(): void
+    {
+        Server::enqueue([
+            new Response(200),
+            new Response(501),
+        ]);
+
+        $file = $this->tempFile(1000);
+        $this->blob->upload($file, new UploadBlobOptions('text/plain', initialTransferSize: 1000));
+
+        $requests = Server::received();
+
+        self::assertCount(1, $requests);
+        self::assertSame('', $requests[0]->getUri()->getQuery());
     }
 
     #[Test]
     public function upload_parallel_blocks_sends_correct_amount_of_requests_with_a_network_request(): void
     {
-        $this->expectNotToPerformAssertions(); // should not throw because of the 501
-
         Server::enqueue([
             new Response(200, body: str_repeat('X', 50_000_000)), // stream for fopen
             ...array_fill(0, 20, new Response(200)), // with network streams some chunks in the beginning are smaller. It should be less than 20 requests still.
@@ -124,5 +169,37 @@ class MockBlobClientTest extends TestCase
         }
 
         $this->blob->upload($stream, new UploadBlobOptions('text/plain', initialTransferSize: 0, maximumTransferSize: 5_000_000));
+
+        $requests = Server::received();
+
+        self::assertGreaterThan(1, count($requests));
+        parse_str($requests[array_key_last($requests)]->getUri()->getQuery(), $query);
+        self::assertSame('blocklist', $query['comp'] ?? null);
+    }
+
+    #[Test]
+    public function upload_block_upload_preserves_explicit_content_hash_header(): void
+    {
+        Server::enqueue([
+            new Response(200),
+            new Response(200),
+            new Response(501),
+        ]);
+
+        $file = $this->tempFile(1000);
+        $contentHash = hash('md5', $file->getContents(), binary: true);
+        $file->rewind();
+
+        $this->blob->upload($file, new UploadBlobOptions(
+            'text/plain',
+            initialTransferSize: 0,
+            maximumTransferSize: 8_000_000,
+            httpHeaders: new BlobHttpHeaders(contentHash: $contentHash),
+        ));
+
+        $requests = Server::received();
+
+        self::assertCount(2, $requests);
+        self::assertSame(base64_encode($contentHash), $requests[1]->getHeaderLine('x-ms-blob-content-md5'));
     }
 }


### PR DESCRIPTION
* Improve block upload performance and make configured concurrency behave as expected.
* Speed up uploads for unknown-length streams in cases where concurrency helps.
* Avoid re-reading the full source stream during block uploads, reducing unnecessary work and making uploads more reliable for stream-based inputs.
* Allow maximumTransferSize to be optional so callers do not need to tune block size themselves in common cases.
* Automatically pick a suitable block size when one is not provided, improving behavior for large uploads while preserving explicit caller configuration.