### PR TITLE
Make azure-oss/storage a meta package and rename Blob to storage-blob

### DIFF
--- a/.github/sync-package.php
+++ b/.github/sync-package.php
@@ -6,14 +6,15 @@ if ('cli' !== PHP_SAPI) {
 }
 
 $mainRepo = 'https://github.com/Azure-OSS/azure-storage-monorepo';
-exec('find src -name composer.json', $packages);
+exec('find src meta -name composer.json 2>/dev/null', $packages);
 
 foreach ($packages as $package) {
     $package = dirname($package);
-    $c = file_get_contents($package.'/.gitattributes');
+    $gitattributesFile = $package.'/.gitattributes';
+    $c = file_exists($gitattributesFile) ? file_get_contents($gitattributesFile) : '';
     $c = preg_replace('{^/\.git.*+\n}m', '', $c);
     $c .= "/.git* export-ignore\n";
-    file_put_contents($package.'/.gitattributes', $c);
+    file_put_contents($gitattributesFile, $c);
 
     @mkdir($package.'/.github');
     file_put_contents($package.'/.github/PULL_REQUEST_TEMPLATE.md', <<<EOTXT

--- a/.github/workflows/push-subtrees.yml
+++ b/.github/workflows/push-subtrees.yml
@@ -14,9 +14,15 @@ jobs:
           - prefix: src/Common
             repo: Azure-OSS/azure-storage-common
             secret: DEPLOY_KEY_COMMON
-          - prefix: src/Blob
+          - prefix: meta
             repo: Azure-OSS/azure-storage-php
+            secret: DEPLOY_KEY_META
+          - prefix: src/Blob
+            repo: Azure-OSS/azure-storage-blob-php
             secret: DEPLOY_KEY_BLOB
+          - prefix: src/Queue
+            repo: Azure-OSS/azure-storage-queue-php
+            secret: DEPLOY_KEY_QUEUE
           - prefix: src/BlobFlysystem
             repo: Azure-OSS/azure-storage-php-adapter-flysystem
             secret: DEPLOY_KEY_BLOB_FLYSYSTEM

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,12 @@
 
 ## Overview
 
-This repository is a PHP monorepo for the Azure Storage SDKs maintained under the `azure-oss` namespace. The codebase is organized by package inside `src/`, with shared infrastructure extracted into `src/Common` and feature-specific SDKs and integrations layered on top of it.
+This repository is a PHP monorepo for the Azure Storage SDKs maintained under the `azure-oss` namespace. The codebase is organized by package inside `src/`, with shared infrastructure extracted into `src/Common` and feature-specific SDKs and integrations layered on top of it. A lightweight meta package also lives in `meta/` and is used for the umbrella `azure-oss/storage` distribution.
 
 At the root you will find:
 
 - `composer.json`: the monorepo-level package, shared dependencies, and root autoload setup.
+- `meta/`: the publishable meta package for `azure-oss/storage`, which currently requires the Blob and Queue SDKs.
 - `src/`: all package source code.
 - `tests/`: the test suites, grouped by package.
 - `infra/`: Azure Bicep templates for provisioning storage resources used during development or validation.
@@ -26,9 +27,19 @@ Shared primitives used across the storage packages.
 
 This is the lowest-level package in the repo. Blob and queue code depend on it.
 
+### `meta`
+
+The umbrella Composer package published as `azure-oss/storage`.
+
+- Contains package metadata only; there is no runtime source code here.
+- Requires the Blob and Queue SDK packages so consumers can install a single package.
+- This is the package that should be subtree-split to the main `storage` repository.
+
+Use this package for umbrella package metadata, dependency aggregation, and split-repo docs.
+
 ### `src/Blob`
 
-The core Azure Blob Storage SDK.
+The core Azure Blob Storage SDK, published as `azure-oss/storage-blob`.
 
 - Top-level clients:
   - `BlobServiceClient.php`
@@ -96,11 +107,14 @@ The packages are layered roughly like this:
 
 `Common` -> `Blob` -> `QueueLaravel`
 
+`meta` -> `Blob` / `Queue`
+
 In practice:
 
 - Put reusable HTTP/auth/SAS utilities in `src/Common`.
 - Put Azure Blob API behavior in `src/Blob`.
 - Put Azure Queue API behavior in `src/Queue`.
+- Put umbrella Composer-package wiring in `meta/`.
 - Put Flysystem-specific behavior in `src/BlobFlysystem`.
 - Put Laravel-specific filesystem behavior in `src/BlobLaravel`.
 - Put Laravel-specific queue behavior in `src/QueueLaravel`.
@@ -124,8 +138,8 @@ When editing a package, start by checking its matching test directory. Feature t
 
 - Root autoloading maps `AzureOss\\Storage\\` to `src/`, while individual subpackages also ship their own `composer.json` files where applicable.
 - `aliases.php` files are there for backwards compatibility and legacy class-name support, not as a primary extension mechanism.
-- Package READMEs live beside the package code in `src/<Package>/README.md`.
-- The `.github/sync-package.php` script scans package manifests in `src/` and maintains subtree-split metadata for publishable packages.
+- Package READMEs live beside the package code in `src/<Package>/README.md`, with the umbrella package README in `meta/README.md`.
+- The `.github/sync-package.php` script scans package manifests in `src/` and `meta/` and maintains subtree-split metadata for publishable packages.
 - `infra/*.bicep` contains deployment templates, not runtime application code.
 - Code style is enforced with Laravel Pint via `vendor/bin/pint`, using the rules in `pint.json`.
 - Static analysis is enforced with PHPStan via `vendor/bin/phpstan --no-progress --memory-limit=2G`, configured in `phpstan.neon` at level 10 over `src/` and `tests/`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ This monorepo contains the following packages:
 
 ### [azure-oss/storage](https://packagist.org/packages/azure-oss/storage) ![Version](https://img.shields.io/packagist/v/azure-oss/storage) ![Total Downloads](https://img.shields.io/packagist/dt/azure-oss/storage)
 
-The core Azure Blob Storage PHP SDK. This is the main package that provides the core functionality for interacting with Azure Blob Storage.
+Meta package that installs both the Blob and Queue SDKs. Use this when you want a single Composer dependency for the core Azure Storage clients.
+
+### [azure-oss/storage-blob](https://packagist.org/packages/azure-oss/storage-blob) ![Version](https://img.shields.io/packagist/v/azure-oss/storage-blob) ![Total Downloads](https://img.shields.io/packagist/dt/azure-oss/storage-blob)
+
+The core Azure Blob Storage PHP SDK. Use this when you only need Blob Storage support.
 
 ### [azure-oss/storage-queue](https://packagist.org/packages/azure-oss/storage-queue) ![Version](https://img.shields.io/packagist/v/azure-oss/storage-queue) ![Total Downloads](https://img.shields.io/packagist/dt/azure-oss/storage-queue)
 

--- a/src/Blob/README.md
+++ b/src/Blob/README.md
@@ -1,7 +1,7 @@
-# Azure Storage PHP
+# Azure Storage Blob PHP
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/azure-oss/storage.svg)](https://packagist.org/packages/azure-oss/storage)
-[![Packagist Downloads](https://img.shields.io/packagist/dt/azure-oss/storage)](https://packagist.org/packages/azure-oss/storage)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/azure-oss/storage-blob.svg)](https://packagist.org/packages/azure-oss/storage-blob)
+[![Packagist Downloads](https://img.shields.io/packagist/dt/azure-oss/storage-blob)](https://packagist.org/packages/azure-oss/storage-blob)
 
 Community-driven PHP SDKs for Azure, because Microsoft won't.
 
@@ -12,6 +12,9 @@ We picked up where they left off.
 <img src="https://azure-oss.github.io/img/logo.svg" width="150" alt="Screenshot">
 
 Our other packages:
+
+- **[azure-oss/storage](https://packagist.org/packages/azure-oss/storage)** – Meta package with Blob + Queue SDKs  
+  ![Downloads](https://img.shields.io/packagist/dt/azure-oss/storage)
 
 - **[azure-oss/storage-blob-flysystem](https://packagist.org/packages/azure-oss/storage-blob-flysystem)** – Flysystem adapter  
   ![Downloads](https://img.shields.io/packagist/dt/azure-oss/storage-blob-flysystem)
@@ -56,7 +59,7 @@ You can read the documentation [here](https://azure-oss.github.io).
 ## Install
 
 ```shell
-composer require azure-oss/storage
+composer require azure-oss/storage-blob
 ```
 
 ## Quickstart
@@ -97,4 +100,4 @@ $blob->deleteIfExists();
 
 ## License
 
-This project is released under the MIT License. See [LICENSE](https://github.com/Azure-OSS/azure-storage-php-monorepo/blob/02759360186be8d2d04bd1e9b2aba3839b6d39dc/LICENSE) for details.
+This project is released under the MIT License. See [LICENSE](https://github.com/Azure-OSS/azure-storage-monorepo/blob/main/LICENSE) for details.

--- a/src/Blob/composer.json
+++ b/src/Blob/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-oss/storage",
+  "name": "azure-oss/storage-blob",
   "description": "Azure Blob Storage PHP SDK",
   "keywords": ["azure", "storage", "php", "sdk"],
   "type": "library",

--- a/src/BlobFlysystem/README.md
+++ b/src/BlobFlysystem/README.md
@@ -13,8 +13,11 @@ We picked up where they left off.
 
 Our other packages:
 
-- **[azure-oss/storage](https://packagist.org/packages/azure-oss/storage)** – Azure Blob Storage SDK  
+- **[azure-oss/storage](https://packagist.org/packages/azure-oss/storage)** – Meta package with Blob + Queue SDKs  
   ![Downloads](https://img.shields.io/packagist/dt/azure-oss/storage)
+
+- **[azure-oss/storage-blob](https://packagist.org/packages/azure-oss/storage-blob)** – Azure Blob Storage SDK  
+  ![Downloads](https://img.shields.io/packagist/dt/azure-oss/storage-blob)
 
 - **[azure-oss/storage-blob-laravel](https://packagist.org/packages/azure-oss/storage-blob-laravel)** – Laravel filesystem driver  
   ![Downloads](https://img.shields.io/packagist/dt/azure-oss/storage-blob-laravel)
@@ -77,4 +80,4 @@ $filesystem->delete('docs/hello.txt');
 
 ## License
 
-This project is released under the MIT License. See [LICENSE](https://github.com/Azure-OSS/azure-storage-php-monorepo/blob/02759360186be8d2d04bd1e9b2aba3839b6d39dc/LICENSE) for details.
+This project is released under the MIT License. See [LICENSE](https://github.com/Azure-OSS/azure-storage-monorepo/blob/main/LICENSE) for details.

--- a/src/BlobFlysystem/composer.json
+++ b/src/BlobFlysystem/composer.json
@@ -24,6 +24,6 @@
   "require": {
     "php": "^8.1",
     "league/flysystem": "^3.28",
-    "azure-oss/storage": "^1.4"
+    "azure-oss/storage-blob": "^1.4"
   }
 }

--- a/src/BlobLaravel/README.md
+++ b/src/BlobLaravel/README.md
@@ -13,8 +13,11 @@ We picked up where they left off.
 
 Our other packages:
 
-- **[azure-oss/storage](https://packagist.org/packages/azure-oss/storage)** – Azure Blob Storage SDK  
+- **[azure-oss/storage](https://packagist.org/packages/azure-oss/storage)** – Meta package with Blob + Queue SDKs  
   ![Downloads](https://img.shields.io/packagist/dt/azure-oss/storage)
+
+- **[azure-oss/storage-blob](https://packagist.org/packages/azure-oss/storage-blob)** – Azure Blob Storage SDK  
+  ![Downloads](https://img.shields.io/packagist/dt/azure-oss/storage-blob)
 
 - **[azure-oss/storage-blob-flysystem](https://packagist.org/packages/azure-oss/storage-blob-flysystem)** – Flysystem adapter  
   ![Downloads](https://img.shields.io/packagist/dt/azure-oss/storage-blob-flysystem)
@@ -52,4 +55,4 @@ Besides shared key via connection string, this driver supports additional authen
 
 ## License
 
-This project is released under the MIT License. See [LICENSE](https://github.com/Azure-OSS/azure-storage-php-monorepo/blob/02759360186be8d2d04bd1e9b2aba3839b6d39dc/LICENSE) for details.
+This project is released under the MIT License. See [LICENSE](https://github.com/Azure-OSS/azure-storage-monorepo/blob/main/LICENSE) for details.

--- a/src/Queue/README.md
+++ b/src/Queue/README.md
@@ -13,8 +13,11 @@ We picked up where they left off.
 
 Our other packages:
 
-- **[azure-oss/storage](https://packagist.org/packages/azure-oss/storage)** – Azure Blob Storage SDK  
+- **[azure-oss/storage](https://packagist.org/packages/azure-oss/storage)** – Meta package with Blob + Queue SDKs  
   ![Downloads](https://img.shields.io/packagist/dt/azure-oss/storage)
+
+- **[azure-oss/storage-blob](https://packagist.org/packages/azure-oss/storage-blob)** – Azure Blob Storage SDK  
+  ![Downloads](https://img.shields.io/packagist/dt/azure-oss/storage-blob)
 
 - **[azure-oss/storage-queue-laravel](https://packagist.org/packages/azure-oss/storage-queue-laravel)** – Laravel Queue connector  
   ![Downloads](https://img.shields.io/packagist/dt/azure-oss/storage-queue-laravel)
@@ -84,4 +87,4 @@ $queue->deleteIfExists();
 
 ## License
 
-This project is released under the MIT License. See [LICENSE](https://github.com/Azure-OSS/azure-storage-php-monorepo/blob/02759360186be8d2d04bd1e9b2aba3839b6d39dc/LICENSE) for details.
+This project is released under the MIT License. See [LICENSE](https://github.com/Azure-OSS/azure-storage-monorepo/blob/main/LICENSE) for details.

--- a/src/QueueLaravel/README.md
+++ b/src/QueueLaravel/README.md
@@ -16,8 +16,11 @@ Our other packages:
 - **[azure-oss/storage-queue](https://packagist.org/packages/azure-oss/storage-queue)** – Azure Storage Queue SDK  
   ![Downloads](https://img.shields.io/packagist/dt/azure-oss/storage-queue)
 
-- **[azure-oss/storage](https://packagist.org/packages/azure-oss/storage)** – Azure Blob Storage SDK  
+- **[azure-oss/storage](https://packagist.org/packages/azure-oss/storage)** – Meta package with Blob + Queue SDKs  
   ![Downloads](https://img.shields.io/packagist/dt/azure-oss/storage)
+
+- **[azure-oss/storage-blob](https://packagist.org/packages/azure-oss/storage-blob)** – Azure Blob Storage SDK  
+  ![Downloads](https://img.shields.io/packagist/dt/azure-oss/storage-blob)
 
 - **[azure-oss/storage-blob-flysystem](https://packagist.org/packages/azure-oss/storage-blob-flysystem)** – Flysystem adapter  
   ![Downloads](https://img.shields.io/packagist/dt/azure-oss/storage-blob-flysystem)
@@ -73,4 +76,4 @@ Set `retry_after` higher than your longest-running jobs on this connection (and 
 
 ## License
 
-This project is released under the MIT License. See [LICENSE](https://github.com/Azure-OSS/azure-storage-php-monorepo/blob/02759360186be8d2d04bd1e9b2aba3839b6d39dc/LICENSE) for details.
+This project is released under the MIT License. See [LICENSE](https://github.com/Azure-OSS/azure-storage-monorepo/blob/main/LICENSE) for details.

--- a/src/QueueLaravel/composer.json
+++ b/src/QueueLaravel/composer.json
@@ -18,7 +18,7 @@
     "php": "^8.1",
     "illuminate/queue": "^10|^11|^12|^13",
     "illuminate/support": "^10|^11|^12|^13",
-    "azure-oss/storage": "^1.4"
+    "azure-oss/storage-queue": "^1.4"
   },
   "extra": {
     "laravel": {
@@ -28,4 +28,3 @@
     }
   }
 }
-


### PR DESCRIPTION
## Summary

This PR restructures the package layout so `azure-oss/storage` becomes an umbrella Composer meta package, while the Blob SDK is published as `azure-oss/storage-blob`.

## Changes

- added a new `meta/` package published as `azure-oss/storage`
- configured the meta package to require:
  - `azure-oss/storage-blob`
  - `azure-oss/storage-queue`
- renamed `src/Blob` package from `azure-oss/storage` to `azure-oss/storage-blob`

## Upgrade Impact

This is a breaking packaging change and should be communicated as part of the `v2.0` release.

Consumers that only use Blob directly will need to move from:

```bash
composer require azure-oss/storage
```

to:

```bash
composer require azure-oss/storage-blob
```

Consumers that want both Blob and Queue can keep using the `azure-oss/storage`


