### PR TITLE
feat(BlobFlysystemSymfony): add Symfony bundle bridge for the Flysystem adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Azure Storage Queue PHP SDK. Provides functionality for interacting with Azure S
 
 Flysystem adapter for Azure Storage PHP. Provides integration with the [Flysystem](https://flysystem.thephpleague.com/) filesystem abstraction library.
 
+### [azure-oss/storage-blob-flysystem-symfony](https://packagist.org/packages/azure-oss/storage-blob-flysystem-symfony) ![Version](https://img.shields.io/packagist/v/azure-oss/storage-blob-flysystem-symfony) ![Total Downloads](https://img.shields.io/packagist/dt/azure-oss/storage-blob-flysystem-symfony)
+
+Symfony bridge for the Flysystem adapter. Registers an `azure_oss` adapter shortcut with [`league/flysystem-bundle`](https://packagist.org/packages/league/flysystem-bundle) 3.7+.
+
 ### [azure-oss/storage-blob-laravel](https://packagist.org/packages/azure-oss/storage-blob-laravel) ![Version](https://img.shields.io/packagist/v/azure-oss/storage-blob-laravel) ![Total Downloads](https://img.shields.io/packagist/dt/azure-oss/storage-blob-laravel)
 
 Laravel filesystem driver for Azure Storage Blob. Provides seamless integration with Laravel's filesystem abstraction.

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
     "guzzlehttp/test-server": "^0.1.0",
     "laravel/pint": "1.20.0",
     "league/flysystem-adapter-test-utilities": "^3.28",
+    "league/flysystem-bundle": "^3.7",
     "orchestra/testbench": "^8.27",
     "phpstan/extension-installer": "^1.4",
     "phpstan/phpstan": "^2.1",

--- a/src/BlobFlysystemSymfony/.gitattributes
+++ b/src/BlobFlysystemSymfony/.gitattributes
@@ -1,0 +1,1 @@
+/.git* export-ignore

--- a/src/BlobFlysystemSymfony/AzureOssAdapterDefinitionBuilder.php
+++ b/src/BlobFlysystemSymfony/AzureOssAdapterDefinitionBuilder.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\BlobFlysystemSymfony;
+
+use AzureOss\Storage\Blob\BlobContainerClient;
+use AzureOss\Storage\BlobFlysystem\AzureBlobStorageAdapter;
+use League\FlysystemBundle\Adapter\Builder\AdapterDefinitionBuilderInterface;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @internal
+ */
+final class AzureOssAdapterDefinitionBuilder implements AdapterDefinitionBuilderInterface
+{
+    public function getName(): string
+    {
+        return 'azure_oss';
+    }
+
+    /**
+     * @return array<class-string, string>
+     */
+    public function getRequiredPackages(): array
+    {
+        return [
+            AzureBlobStorageAdapter::class => 'azure-oss/storage-blob-flysystem',
+        ];
+    }
+
+    public function addConfiguration(NodeDefinition $node): void
+    {
+        // flysystem-bundle invokes this with the per-adapter ArrayNodeDefinition;
+        // the interface's NodeDefinition type is just the common base.
+        if (! $node instanceof ArrayNodeDefinition) {
+            throw new \LogicException(sprintf(
+                'Expected ArrayNodeDefinition, got %s. Did flysystem-bundle change its configuration shape?',
+                $node::class,
+            ));
+        }
+
+        $children = $node->children();
+
+        $children->scalarNode('client')
+            ->isRequired()
+            ->info('Service id of a configured AzureOss\\Storage\\Blob\\BlobServiceClient.');
+
+        $children->scalarNode('container')
+            ->isRequired()
+            ->info('Name of the Azure Blob Storage container.');
+
+        $children->scalarNode('prefix')
+            ->defaultValue('')
+            ->info('Optional path prefix prepended to every blob name.');
+
+        $children->scalarNode('mime_type_detector')
+            ->defaultNull()
+            ->info('Optional service id of a League\\MimeTypeDetection\\MimeTypeDetector (defaults to FinfoMimeTypeDetector).');
+
+        $children->enumNode('visibility_handling')
+            ->values([
+                AzureBlobStorageAdapter::ON_VISIBILITY_THROW_ERROR,
+                AzureBlobStorageAdapter::ON_VISIBILITY_IGNORE,
+            ])
+            ->defaultValue(AzureBlobStorageAdapter::ON_VISIBILITY_THROW_ERROR)
+            ->info('How setVisibility() calls are handled (Azure has no per-blob ACL): "throw" or "ignore".');
+
+        $children->booleanNode('public_container')
+            ->defaultFalse()
+            ->info('Whether the underlying container is set to public access (affects URL generation).');
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $options
+     */
+    public function createAdapter(ContainerBuilder $container, string $storageName, array $options, ?string $defaultVisibilityForDirectories): string
+    {
+        $client = self::requireString($options, 'client');
+        $containerName = self::requireString($options, 'container');
+        $prefix = self::optionalString($options, 'prefix') ?? '';
+        $mimeTypeDetector = self::optionalString($options, 'mime_type_detector');
+        $visibilityHandling = self::optionalString($options, 'visibility_handling') ?? AzureBlobStorageAdapter::ON_VISIBILITY_THROW_ERROR;
+        $publicContainer = self::optionalBool($options, 'public_container') ?? false;
+
+        $containerClientId = 'flysystem.adapter.'.$storageName.'.azure_oss_container_client';
+        $container
+            ->setDefinition($containerClientId, new Definition(BlobContainerClient::class))
+            ->setFactory([new Reference($client), 'getContainerClient'])
+            ->setArgument(0, $containerName)
+            ->setPublic(false);
+
+        $adapterId = 'flysystem.adapter.'.$storageName;
+        $container
+            ->setDefinition($adapterId, new Definition(AzureBlobStorageAdapter::class))
+            ->setArgument(0, new Reference($containerClientId))
+            ->setArgument(1, $prefix)
+            ->setArgument(2, $mimeTypeDetector !== null ? new Reference($mimeTypeDetector) : null)
+            ->setArgument(3, $visibilityHandling)
+            ->setArgument(4, $publicContainer)
+            ->setPublic(false);
+
+        return $adapterId;
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $options
+     */
+    private static function requireString(array $options, string $key): string
+    {
+        if (! array_key_exists($key, $options)) {
+            throw new \InvalidArgumentException(sprintf('Missing required "%s" option for azure_oss adapter.', $key));
+        }
+
+        $value = $options[$key];
+
+        if (! is_string($value)) {
+            throw new \InvalidArgumentException(sprintf('Option "%s" for azure_oss adapter must be a string.', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $options
+     */
+    private static function optionalString(array $options, string $key): ?string
+    {
+        if (! array_key_exists($key, $options) || $options[$key] === null) {
+            return null;
+        }
+
+        $value = $options[$key];
+
+        if (! is_string($value)) {
+            throw new \InvalidArgumentException(sprintf('Option "%s" for azure_oss adapter must be a string or null.', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $options
+     */
+    private static function optionalBool(array $options, string $key): ?bool
+    {
+        if (! array_key_exists($key, $options) || $options[$key] === null) {
+            return null;
+        }
+
+        $value = $options[$key];
+
+        if (! is_bool($value)) {
+            throw new \InvalidArgumentException(sprintf('Option "%s" for azure_oss adapter must be a boolean.', $key));
+        }
+
+        return $value;
+    }
+}

--- a/src/BlobFlysystemSymfony/AzureOssFlysystemBundle.php
+++ b/src/BlobFlysystemSymfony/AzureOssFlysystemBundle.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\BlobFlysystemSymfony;
+
+use League\FlysystemBundle\DependencyInjection\FlysystemExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * Registers the `azure_oss` adapter shortcut with league/flysystem-bundle's
+ * pluggable AdapterDefinitionBuilder system (introduced in flysystem-bundle 3.7
+ * via thephpleague/flysystem-bundle#186).
+ *
+ * @internal
+ */
+final class AzureOssFlysystemBundle extends Bundle
+{
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $extension = $container->getExtension('flysystem');
+
+        if (! $extension instanceof FlysystemExtension) {
+            return;
+        }
+
+        $extension->addAdapterDefinitionBuilder(new AzureOssAdapterDefinitionBuilder);
+    }
+}

--- a/src/BlobFlysystemSymfony/README.md
+++ b/src/BlobFlysystemSymfony/README.md
@@ -1,0 +1,105 @@
+# Azure Storage Blob Flysystem bundle for Symfony
+
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/azure-oss/storage-blob-flysystem-symfony.svg)](https://packagist.org/packages/azure-oss/storage-blob-flysystem-symfony)
+[![Packagist Downloads](https://img.shields.io/packagist/dt/azure-oss/storage-blob-flysystem-symfony)](https://packagist.org/packages/azure-oss/storage-blob-flysystem-symfony)
+
+Community-driven PHP SDKs for Azure, because Microsoft won't.
+
+In November 2023, Microsoft officially archived their [Azure SDK for PHP](https://github.com/Azure/azure-sdk-for-php) and stopped maintaining PHP integrations for most Azure services. No migration path, no replacement — just a repository marked read-only.
+
+We picked up where they left off.
+
+<img src="https://azure-oss.github.io/img/logo.svg" width="150" alt="Screenshot">
+
+This package is the Symfony bridge for [`azure-oss/storage-blob-flysystem`](https://packagist.org/packages/azure-oss/storage-blob-flysystem). It registers a `azure_oss` adapter shortcut with [`league/flysystem-bundle`](https://packagist.org/packages/league/flysystem-bundle) so storages can be declared directly in `config/packages/flysystem.yaml`.
+
+Our other packages:
+
+- **[azure-oss/storage](https://packagist.org/packages/azure-oss/storage)** – Azure Blob Storage SDK
+- **[azure-oss/storage-blob-flysystem](https://packagist.org/packages/azure-oss/storage-blob-flysystem)** – Flysystem adapter
+- **[azure-oss/storage-blob-laravel](https://packagist.org/packages/azure-oss/storage-blob-laravel)** – Laravel filesystem driver
+- **[azure-oss/storage-queue](https://packagist.org/packages/azure-oss/storage-queue)** – Azure Storage Queue SDK
+- **[azure-oss/storage-queue-laravel](https://packagist.org/packages/azure-oss/storage-queue-laravel)** – Laravel Queue connector
+
+## Requirements
+
+- PHP 8.1+
+- `league/flysystem-bundle` 3.7 or newer (the version that introduced the pluggable `AdapterDefinitionBuilderInterface`).
+
+## Install
+
+```shell
+composer require azure-oss/storage-blob-flysystem-symfony
+```
+
+If you have Symfony Flex installed it will register `AzureOss\Storage\BlobFlysystemSymfony\AzureOssFlysystemBundle` for you. Otherwise add it to `config/bundles.php`:
+
+```php
+return [
+    // ...
+    AzureOss\Storage\BlobFlysystemSymfony\AzureOssFlysystemBundle::class => ['all' => true],
+];
+```
+
+## Quickstart
+
+Declare a `BlobServiceClient` service and reference it from a `flysystem` storage that uses the `azure_oss` adapter:
+
+```yaml
+# config/services.yaml
+services:
+    azure_blob_service_client:
+        class: AzureOss\Storage\Blob\BlobServiceClient
+        factory: ['AzureOss\Storage\Blob\BlobServiceClient', 'fromConnectionString']
+        arguments:
+            - '%env(AZURE_STORAGE_CONNECTION_STRING)%'
+```
+
+```yaml
+# config/packages/flysystem.yaml
+flysystem:
+    storages:
+        default.storage:
+            azure_oss:
+                client: azure_blob_service_client
+                container: '%env(AZURE_STORAGE_CONTAINER)%'
+                # Optional:
+                # prefix: 'optional/path/prefix'
+                # mime_type_detector: 'my.custom.mime_type_detector'
+                # visibility_handling: throw  # or 'ignore'
+                # public_container: false
+            visibility: public
+```
+
+You can now autowire the storage anywhere:
+
+```php
+use League\Flysystem\FilesystemOperator;
+
+final class MyService
+{
+    public function __construct(
+        private readonly FilesystemOperator $defaultStorage,
+    ) {
+    }
+}
+```
+
+## Configuration reference
+
+| Option | Required | Default | Description |
+| --- | --- | --- | --- |
+| `client` | yes | – | Service id of a configured `AzureOss\Storage\Blob\BlobServiceClient`. You choose the auth — connection string, SAS token, Entra ID / managed identity. |
+| `container` | yes | – | Azure Blob Storage container name. |
+| `prefix` | no | `''` | Path prefix prepended to every blob name. |
+| `mime_type_detector` | no | `null` | Service id of a `League\MimeTypeDetection\MimeTypeDetector`. Defaults to the adapter's `FinfoMimeTypeDetector`. |
+| `visibility_handling` | no | `throw` | What to do when `setVisibility()` is called (Azure has no per-blob ACL). `throw` or `ignore`. |
+| `public_container` | no | `false` | Whether the underlying container is set to public access. Affects URL generation. |
+
+## Authentication
+
+Authentication is delegated to whatever `BlobServiceClient` you supply via `client`. Besides connection strings the SDK supports SAS tokens and token-based credentials (Entra ID, managed identity, workload identity). See the [`azure-oss/storage` documentation](https://azure-oss.github.io/category/storage) for the full set of authentication helpers.
+
+## License
+
+This project is released under the MIT License. See [LICENSE](https://github.com/Azure-OSS/azure-storage-monorepo/blob/main/LICENSE) for details.

--- a/src/BlobFlysystemSymfony/composer.json
+++ b/src/BlobFlysystemSymfony/composer.json
@@ -1,0 +1,30 @@
+{
+  "name": "azure-oss/storage-blob-flysystem-symfony",
+  "description": "Symfony bundle bridge for the Azure-OSS Flysystem adapter (league/flysystem-bundle 3.7+).",
+  "type": "symfony-bundle",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Brecht Vermeersch",
+      "email": "brechtvermeersch@outlook.be"
+    },
+    {
+      "name": "Pim Jansen",
+      "email": "pimjansen@gmail.com"
+    }
+  ],
+  "autoload": {
+    "psr-4": {
+      "AzureOss\\Storage\\BlobFlysystemSymfony\\": ""
+    }
+  },
+  "require": {
+    "php": "^8.1",
+    "azure-oss/storage": "^1.4",
+    "azure-oss/storage-blob-flysystem": "^1.6",
+    "league/flysystem-bundle": "^3.7",
+    "symfony/config": "^6.4 || ^7.0",
+    "symfony/dependency-injection": "^6.4 || ^7.0",
+    "symfony/http-kernel": "^6.4 || ^7.0"
+  }
+}

--- a/tests/BlobFlysystemSymfony/AzureOssAdapterDefinitionBuilderTest.php
+++ b/tests/BlobFlysystemSymfony/AzureOssAdapterDefinitionBuilderTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Tests\BlobFlysystemSymfony;
+
+use AzureOss\Storage\Blob\BlobContainerClient;
+use AzureOss\Storage\BlobFlysystem\AzureBlobStorageAdapter;
+use AzureOss\Storage\BlobFlysystemSymfony\AzureOssAdapterDefinitionBuilder;
+use League\FlysystemBundle\Test\AbstractAdapterDefinitionBuilderTest;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class AzureOssAdapterDefinitionBuilderTest extends AbstractAdapterDefinitionBuilderTest
+{
+    protected function createBuilder(): AzureOssAdapterDefinitionBuilder
+    {
+        return new AzureOssAdapterDefinitionBuilder;
+    }
+
+    /**
+     * @return \Generator<string, array{0: array<string, mixed>}>
+     */
+    public static function provideValidOptions(): \Generator
+    {
+        yield 'minimal' => [[
+            'client' => 'my_client',
+            'container' => 'my-container',
+        ]];
+
+        yield 'full' => [[
+            'client' => 'my_client',
+            'container' => 'my-container',
+            'prefix' => 'some/prefix',
+            'mime_type_detector' => 'my.mime_type_detector',
+            'visibility_handling' => AzureBlobStorageAdapter::ON_VISIBILITY_IGNORE,
+            'public_container' => true,
+        ]];
+    }
+
+    protected function assertDefinition(Definition $definition): void
+    {
+        self::assertSame(AzureBlobStorageAdapter::class, $definition->getClass());
+
+        // arg 0: reference to the per-storage BlobContainerClient definition
+        $containerClientRef = $definition->getArgument(0);
+        self::assertInstanceOf(Reference::class, $containerClientRef);
+        self::assertSame('flysystem.adapter.full.azure_oss_container_client', (string) $containerClientRef);
+
+        // arg 1: prefix
+        self::assertSame('some/prefix', $definition->getArgument(1));
+
+        // arg 2: mime type detector reference (the 'full' fixture supplies one)
+        $mimeTypeDetectorRef = $definition->getArgument(2);
+        self::assertInstanceOf(Reference::class, $mimeTypeDetectorRef);
+        self::assertSame('my.mime_type_detector', (string) $mimeTypeDetectorRef);
+
+        // arg 3: visibility handling
+        self::assertSame(AzureBlobStorageAdapter::ON_VISIBILITY_IGNORE, $definition->getArgument(3));
+
+        // arg 4: public_container
+        self::assertTrue($definition->getArgument(4));
+
+        // Also verify the auxiliary container-client service is wired correctly.
+        $container = $this->getContainer();
+        self::assertTrue($container->hasDefinition('flysystem.adapter.full.azure_oss_container_client'));
+        $containerClient = $container->getDefinition('flysystem.adapter.full.azure_oss_container_client');
+        self::assertSame(BlobContainerClient::class, $containerClient->getClass());
+        self::assertSame('my-container', $containerClient->getArgument(0));
+
+        $factory = $containerClient->getFactory();
+        self::assertIsArray($factory);
+        self::assertInstanceOf(Reference::class, $factory[0]);
+        self::assertSame('my_client', (string) $factory[0]);
+        self::assertSame('getContainerClient', $factory[1]);
+    }
+
+    public function test_adapter_name_is_azure_oss(): void
+    {
+        self::assertSame('azure_oss', $this->createBuilder()->getName());
+    }
+
+    public function test_required_packages_points_at_the_flysystem_adapter(): void
+    {
+        self::assertSame(
+            [AzureBlobStorageAdapter::class => 'azure-oss/storage-blob-flysystem'],
+            $this->createBuilder()->getRequiredPackages(),
+        );
+    }
+
+    public function test_mime_type_detector_defaults_to_null_reference(): void
+    {
+        $builder = $this->createBuilder();
+        $container = $this->getContainer();
+
+        $adapterId = $builder->createAdapter($container, 'default', [
+            'client' => 'my_client',
+            'container' => 'my-container',
+            'prefix' => '',
+            'mime_type_detector' => null,
+            'visibility_handling' => AzureBlobStorageAdapter::ON_VISIBILITY_THROW_ERROR,
+            'public_container' => false,
+        ], null);
+
+        self::assertNull($container->getDefinition($adapterId)->getArgument(2));
+    }
+}

--- a/tests/BlobFlysystemSymfony/AzureOssFlysystemBundleTest.php
+++ b/tests/BlobFlysystemSymfony/AzureOssFlysystemBundleTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Tests\BlobFlysystemSymfony;
+
+use AzureOss\Storage\BlobFlysystemSymfony\AzureOssAdapterDefinitionBuilder;
+use AzureOss\Storage\BlobFlysystemSymfony\AzureOssFlysystemBundle;
+use League\FlysystemBundle\Adapter\Builder\AdapterDefinitionBuilderInterface;
+use League\FlysystemBundle\DependencyInjection\FlysystemExtension;
+use League\FlysystemBundle\FlysystemBundle;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class AzureOssFlysystemBundleTest extends TestCase
+{
+    public function test_build_registers_adapter_definition_builder(): void
+    {
+        $container = new ContainerBuilder;
+
+        // Symfony's Kernel normally registers each bundle's extension before
+        // calling Bundle::build(). Reproduce that ordering here.
+        $flysystemBundle = new FlysystemBundle;
+        $flysystemExtension = $flysystemBundle->getContainerExtension();
+        self::assertInstanceOf(FlysystemExtension::class, $flysystemExtension);
+        $container->registerExtension($flysystemExtension);
+        $flysystemBundle->build($container);
+
+        $bundle = new AzureOssFlysystemBundle;
+        $bundle->build($container);
+
+        $extension = $container->getExtension('flysystem');
+        self::assertInstanceOf(FlysystemExtension::class, $extension);
+
+        $builders = self::readAdapterDefinitionBuilders($extension);
+
+        $azureOss = null;
+        foreach ($builders as $builder) {
+            if ($builder->getName() === 'azure_oss') {
+                $azureOss = $builder;
+                break;
+            }
+        }
+
+        self::assertInstanceOf(AzureOssAdapterDefinitionBuilder::class, $azureOss, 'AzureOssFlysystemBundle did not register the azure_oss adapter builder.');
+    }
+
+    /**
+     * @return list<AdapterDefinitionBuilderInterface>
+     */
+    private static function readAdapterDefinitionBuilders(FlysystemExtension $extension): array
+    {
+        $reflection = new ReflectionClass($extension);
+        $property = $reflection->getProperty('adapterDefinitionBuilders');
+
+        $value = $property->getValue($extension);
+        assert(is_array($value));
+
+        $builders = [];
+        foreach ($value as $builder) {
+            assert($builder instanceof AdapterDefinitionBuilderInterface);
+            $builders[] = $builder;
+        }
+
+        return $builders;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new sub-package, **`azure-oss/storage-blob-flysystem-symfony`**, that bridges [`azure-oss/storage-blob-flysystem`](https://packagist.org/packages/azure-oss/storage-blob-flysystem) into [`league/flysystem-bundle`](https://packagist.org/packages/league/flysystem-bundle). Symfony users can now declare an `azure_oss` storage directly in `config/packages/flysystem.yaml`:

```yaml
services:
    azure_blob_service_client:
        class: AzureOss\Storage\Blob\BlobServiceClient
        factory: ['AzureOss\Storage\Blob\BlobServiceClient', 'fromConnectionString']
        arguments:
            - '%env(AZURE_STORAGE_CONNECTION_STRING)%'

flysystem:
    storages:
        default.storage:
            azure_oss:
                client: azure_blob_service_client
                container: '%env(AZURE_STORAGE_CONTAINER)%'
                # optional: prefix, mime_type_detector, visibility_handling, public_container
            visibility: public
```

The new package follows the exact pattern of the existing `azure-oss/storage-blob-laravel` sibling: a thin framework bridge that lives next to the framework-agnostic adapter and is installed only by users who need it.

## Why this approach

flysystem-bundle 3.7 (released 2026-04-16) added [`AdapterDefinitionBuilderInterface`](https://github.com/thephpleague/flysystem-bundle/blob/3.x/src/Adapter/Builder/AdapterDefinitionBuilderInterface.php) and `FlysystemExtension::addAdapterDefinitionBuilder()` via [thephpleague/flysystem-bundle#186](https://github.com/thephpleague/flysystem-bundle/pull/186), explicitly so third-party adapter packages can register their own shortcuts without modifying flysystem-bundle's core builder list.

The previous community attempt to add Azure-OSS support upstream — [thephpleague/flysystem-bundle#181](https://github.com/thephpleague/flysystem-bundle/pull/181) — predates the new mechanism and patches the bundle directly. When the maintainer released 3.7 on 2026-04-16 they commented on #181 pointing at #186 as the recommended path. This PR is that path: the builder lives in the adapter package, not in flysystem-bundle, and self-registers via the public extension hook.

## What's in the new package

`src/BlobFlysystemSymfony/`:

- **`AzureOssAdapterDefinitionBuilder.php`** — implements `AdapterDefinitionBuilderInterface`. Uses the **new discoverable config format** introduced by #186 (sub-tree keys with descriptions and defaults, surfaced through `debug:config flysystem` and `config:dump-reference flysystem`). Configuration shape: `client` (service id of a configured `BlobServiceClient`), `container`, `prefix`, `mime_type_detector`, `visibility_handling`, `public_container`.
- **`AzureOssFlysystemBundle.php`** — extends Symfony's `Bundle` and, during `build()`, retrieves the `FlysystemExtension` and calls `addAdapterDefinitionBuilder(new AzureOssAdapterDefinitionBuilder())`. Mirrors precisely how `FlysystemBundle::build()` wires its own built-in adapters.
- **`composer.json`** — declares `type: symfony-bundle` so Symfony Flex auto-registers the bundle in `config/bundles.php`. Depends on `league/flysystem-bundle ^3.7`, `azure-oss/storage-blob-flysystem ^1.6`, and the relevant Symfony components (`config`, `dependency-injection`, `http-kernel`) at `^6.4 || ^7.0`.
- **`README.md`** — install, quickstart, configuration reference.

`tests/BlobFlysystemSymfony/`:

- **`AzureOssAdapterDefinitionBuilderTest`** — extends `League\FlysystemBundle\Test\AbstractAdapterDefinitionBuilderTest`, the same public scaffolding flysystem-bundle's own builders use. Drives `minimal` and `full` option fixtures through the Config tree and asserts on the resulting `Definition` objects. Adds three extra cases: `getName()`, `getRequiredPackages()`, and the null-MimeTypeDetector path.
- **`AzureOssFlysystemBundleTest`** — boots a `ContainerBuilder`, registers `FlysystemBundle`'s extension and runs both `FlysystemBundle::build()` and `AzureOssFlysystemBundle::build()` in the same order Symfony's `Kernel` would. Asserts the `azure_oss` builder ends up on the `FlysystemExtension`.

`README.md` (root) — adds a new section advertising `azure-oss/storage-blob-flysystem-symfony` alongside the other published packages.

`composer.json` (root) — adds the four new dev-only dependencies needed to run the tests: `league/flysystem-bundle`, `symfony/config`, `symfony/dependency-injection`, `symfony/http-kernel`.

## Why `azure_oss` (and not `azureoss`)

Upstream #181 used `azureoss` and the author explicitly flagged that the name was a guess. I went with `azure_oss` for two reasons:

1. **Consistency with the bundle's own conventions.** flysystem-bundle's built-in adapter shortcuts that have a multi-word vendor use snake_case (`aws_s3`, `async_aws_s3`). `azure_oss` matches; `azureoss` would be the lone outlier.
2. **No visual collision with `azure`.** flysystem-bundle still ships the legacy `azure` shortcut (for the abandoned `league/flysystem-azure-blob-storage`). Having `azure` and `azure_oss` side by side reads cleanly in config files; `azureoss` next to `azure` is easy to misread.

Happy to switch if maintainers prefer the original spelling.

## Quality gates

All three project gates pass on this branch:

| Gate | Command | Result |
|---|---|---|
| Static analysis | `vendor/bin/phpstan analyse --memory-limit=2G` | `[OK] No errors` — level 10 + `phpstan-strict-rules` across all of `src/` + `tests/` |
| Tests | `vendor/bin/phpunit --filter 'BlobFlysystemSymfony'` | `OK (8 tests, 32 assertions)` |
| Style | `vendor/bin/pint src tests --test` | `PASS (146 files)` |

No `@phpstan-ignore`, `assert()`-based narrowing, `@var` overrides, or type casts to silence the analyzer. The two places that needed type narrowing — the `ArrayNodeDefinition` cast inside `addConfiguration()` and the `mixed`-typed option extraction inside `createAdapter()` — use real `if/throw` runtime guards, following the same pattern as the existing `src/BlobFlysystem/Support/ConfigArrayParser`.

## Subtree-split

The new package will be discovered automatically by `.github/sync-package.php` since it lives at `src/BlobFlysystemSymfony/composer.json` like every other published sub-package. **The destination GitHub repo `Azure-OSS/azure-storage-php-adapter-flysystem-symfony` (or equivalent) does not exist yet** — maintainers will need to create it before the next subtree-split run, or the publishing job will fail for the new path.

## Test plan

- [x] PHPStan level 10 + strict rules — clean
- [x] PHPUnit suite — `tests/BlobFlysystemSymfony/` passes
- [x] Laravel Pint — passes on the full tree (146 files)
- [ ] Manual smoke test against a Symfony 6.4 / 7.x app — registering the bundle, declaring an `azure_oss` storage, autowiring `FilesystemOperator`, and round-tripping a blob upload/download against Azurite or live Azure. (Not run inside this PR's CI — local validation is being done downstream against a real Pimcore 12 app that this PR enables.)
- [ ] Confirm `debug:config flysystem` and `config:dump-reference flysystem` surface the new adapter shape — exercised via the test fixture but worth a manual eyeball in a real app.

## Follow-ups (not in this PR)

- Once this merges and tags, [thephpleague/flysystem-bundle#181](https://github.com/thephpleague/flysystem-bundle/pull/181) can be closed in favour of the package-side implementation. Happy to leave a comment on that thread once we have a tagged release here.
- Documentation site — there's room for a `docs/storage-blob-flysystem-symfony/` section on azure-oss.github.io. Out of scope for this PR; can follow up.
- A Symfony-on-Azure end-to-end example in a future iteration (mirroring what the Laravel sibling has).