### PR TITLE
feat(blob-laravel): allow configuring HTTP timeouts for the azure disk

### DIFF
--- a/src/BlobLaravel/AzureStorageBlobAdapter.php
+++ b/src/BlobLaravel/AzureStorageBlobAdapter.php
@@ -15,12 +15,16 @@ use AzureOss\Identity\TokenCredential;
 use AzureOss\Identity\WorkloadIdentityCredential;
 use AzureOss\Identity\WorkloadIdentityCredentialOptions;
 use AzureOss\Storage\Blob\BlobServiceClient;
+use AzureOss\Storage\Blob\Models\BlobServiceClientOptions;
 use AzureOss\Storage\BlobFlysystem\AzureBlobStorageAdapter;
 use AzureOss\Storage\Common\Auth\StorageSharedKeyCredential;
+use AzureOss\Storage\Common\Middleware\HttpClientOptions;
+use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Uri;
 use Illuminate\Filesystem\FilesystemAdapter;
 use League\Flysystem\Config;
 use League\Flysystem\Filesystem;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -53,7 +57,10 @@ final class AzureStorageBlobAdapter extends FilesystemAdapter
      *     container: string,
      *     prefix?: string,
      *     root?: string,
-     *     is_public_container?: bool
+     *     is_public_container?: bool,
+     *     timeout?: int,
+     *     connect_timeout?: int,
+     *     verify_ssl?: bool
      * }  $config
      */
     public function __construct(array $config)
@@ -97,11 +104,16 @@ final class AzureStorageBlobAdapter extends FilesystemAdapter
      *     container: string,
      *     prefix?: string,
      *     root?: string,
-     *     is_public_container?: bool
+     *     is_public_container?: bool,
+     *     timeout?: int,
+     *     connect_timeout?: int,
+     *     verify_ssl?: bool
      * }  $config
      */
     private static function createBlobServiceClient(array $config): BlobServiceClient
     {
+        $httpClientOptions = self::createHttpClientOptions($config);
+
         $connectionString = $config['connection_string'] ?? null;
         if ($connectionString !== null && $connectionString !== '') {
             $hasEndpointOrAccountName = isset($config['endpoint']) || isset($config['account_name']);
@@ -120,7 +132,10 @@ final class AzureStorageBlobAdapter extends FilesystemAdapter
                 throw new \InvalidArgumentException('Cannot use both [connection_string] and token-based credentials in the disk configuration.');
             }
 
-            return BlobServiceClient::fromConnectionString($connectionString);
+            return BlobServiceClient::fromConnectionString(
+                $connectionString,
+                new BlobServiceClientOptions($httpClientOptions),
+            );
         }
 
         if (! isset($config['endpoint']) && ! isset($config['account_name'])) {
@@ -130,9 +145,26 @@ final class AzureStorageBlobAdapter extends FilesystemAdapter
         }
 
         $uri = self::buildBlobEndpointUri($config);
-        $credential = self::createCredential($config);
+        $credential = self::createCredential($config, $httpClientOptions);
 
-        return new BlobServiceClient($uri, $credential);
+        return new BlobServiceClient($uri, $credential, new BlobServiceClientOptions($httpClientOptions));
+    }
+
+    /**
+     * Build the shared HTTP options for both the Blob API calls and the Entra ID
+     * token request. Leaving these unset keeps the previous behaviour (no explicit
+     * timeouts); setting them prevents a slow connection — in particular a stalled
+     * token request to the identity provider — from hanging the caller indefinitely.
+     *
+     * @param  array{timeout?: int, connect_timeout?: int, verify_ssl?: bool}  $config
+     */
+    private static function createHttpClientOptions(array $config): HttpClientOptions
+    {
+        return new HttpClientOptions(
+            timeout: $config['timeout'] ?? null,
+            connectTimeout: $config['connect_timeout'] ?? null,
+            verifySsl: $config['verify_ssl'] ?? null,
+        );
     }
 
     /**
@@ -149,10 +181,15 @@ final class AzureStorageBlobAdapter extends FilesystemAdapter
      *     federated_token_file?: string
      * }  $config
      */
-    private static function createCredential(array $config): StorageSharedKeyCredential|TokenCredential
+    private static function createCredential(array $config, HttpClientOptions $httpClientOptions): StorageSharedKeyCredential|TokenCredential
     {
         $authorityHost = $config['authority_host'] ?? null;
         $credentialType = $config['credential'] ?? null;
+
+        // Only build a custom HTTP client for the token request when at least one
+        // HTTP option is configured; otherwise pass null so the credential keeps
+        // using its own auto-discovered client (unchanged default behaviour).
+        $tokenHttpClient = self::createTokenHttpClient($httpClientOptions);
 
         $tenantId = $config['tenant_id'] ?? null;
         $clientId = $config['client_id'] ?? null;
@@ -160,7 +197,7 @@ final class AzureStorageBlobAdapter extends FilesystemAdapter
 
         if ($credentialType === null) {
             if ($tenantId !== null && $clientId !== null && $clientSecret !== null) {
-                return self::createClientSecretCredential($config, $authorityHost);
+                return self::createClientSecretCredential($config, $authorityHost, $tokenHttpClient);
             }
 
             throw new \InvalidArgumentException('The [credential] must be provided in the disk configuration when not using [connection_string].');
@@ -168,14 +205,21 @@ final class AzureStorageBlobAdapter extends FilesystemAdapter
 
         return match (strtolower($credentialType)) {
             'shared_key' => self::createSharedKeyCredential($config),
-            'client_secret' => self::createClientSecretCredential($config, $authorityHost),
-            'client_certificate' => self::createClientCertificateCredential($config, $authorityHost),
-            'workload_identity' => self::createWorkloadIdentityCredential($config, $authorityHost),
-            'managed_identity' => self::createManagedIdentityCredential($config, $authorityHost),
+            'client_secret' => self::createClientSecretCredential($config, $authorityHost, $tokenHttpClient),
+            'client_certificate' => self::createClientCertificateCredential($config, $authorityHost, $tokenHttpClient),
+            'workload_identity' => self::createWorkloadIdentityCredential($config, $authorityHost, $tokenHttpClient),
+            'managed_identity' => self::createManagedIdentityCredential($config, $authorityHost, $tokenHttpClient),
             default => throw new \InvalidArgumentException(
                 'Unsupported [credential]. Supported values: [shared_key, client_secret, client_certificate, workload_identity, managed_identity].',
             ),
         };
+    }
+
+    private static function createTokenHttpClient(HttpClientOptions $httpClientOptions): ?ClientInterface
+    {
+        $guzzleConfig = $httpClientOptions->toGuzzleHttpClientConfig();
+
+        return $guzzleConfig === [] ? null : new Client($guzzleConfig);
     }
 
     /**
@@ -196,7 +240,7 @@ final class AzureStorageBlobAdapter extends FilesystemAdapter
     /**
      * @param  array{tenant_id?: string, client_id?: string, client_secret?: string}  $config
      */
-    private static function createClientSecretCredential(array $config, ?string $authorityHost): ClientSecretCredential
+    private static function createClientSecretCredential(array $config, ?string $authorityHost, ?ClientInterface $httpClient): ClientSecretCredential
     {
         $tenantId = $config['tenant_id'] ?? null;
         $clientId = $config['client_id'] ?? null;
@@ -210,14 +254,17 @@ final class AzureStorageBlobAdapter extends FilesystemAdapter
             $tenantId,
             $clientId,
             $clientSecret,
-            new ClientSecretCredentialOptions(authorityHost: $authorityHost ?? AzureAuthorityHosts::AZURE_PUBLIC_CLOUD),
+            new ClientSecretCredentialOptions(
+                authorityHost: $authorityHost ?? AzureAuthorityHosts::AZURE_PUBLIC_CLOUD,
+                httpClient: $httpClient,
+            ),
         );
     }
 
     /**
      * @param  array{tenant_id?: string, client_id?: string, client_certificate_path?: string, client_certificate_password?: string}  $config
      */
-    private static function createClientCertificateCredential(array $config, ?string $authorityHost): ClientCertificateCredential
+    private static function createClientCertificateCredential(array $config, ?string $authorityHost, ?ClientInterface $httpClient): ClientCertificateCredential
     {
         $tenantId = $config['tenant_id'] ?? null;
         $clientId = $config['client_id'] ?? null;
@@ -233,14 +280,17 @@ final class AzureStorageBlobAdapter extends FilesystemAdapter
             $clientId,
             $certificatePath,
             $certificatePassword,
-            new ClientCertificateCredentialOptions(authorityHost: $authorityHost ?? AzureAuthorityHosts::AZURE_PUBLIC_CLOUD),
+            new ClientCertificateCredentialOptions(
+                authorityHost: $authorityHost ?? AzureAuthorityHosts::AZURE_PUBLIC_CLOUD,
+                httpClient: $httpClient,
+            ),
         );
     }
 
     /**
      * @param  array{tenant_id?: string, client_id?: string, federated_token_file?: string}  $config
      */
-    private static function createWorkloadIdentityCredential(array $config, ?string $authorityHost): WorkloadIdentityCredential
+    private static function createWorkloadIdentityCredential(array $config, ?string $authorityHost, ?ClientInterface $httpClient): WorkloadIdentityCredential
     {
         $tenantId = $config['tenant_id'] ?? null;
         $clientId = $config['client_id'] ?? null;
@@ -252,6 +302,7 @@ final class AzureStorageBlobAdapter extends FilesystemAdapter
                 clientId: $clientId,
                 tenantId: $tenantId,
                 tokenFilePath: $tokenFilePath,
+                httpClient: $httpClient,
             )
         );
     }
@@ -259,7 +310,7 @@ final class AzureStorageBlobAdapter extends FilesystemAdapter
     /**
      * @param  array{client_id?: string}  $config
      */
-    private static function createManagedIdentityCredential(array $config, ?string $authorityHost): ManagedIdentityCredential
+    private static function createManagedIdentityCredential(array $config, ?string $authorityHost, ?ClientInterface $httpClient): ManagedIdentityCredential
     {
         $clientId = $config['client_id'] ?? null;
 
@@ -267,6 +318,7 @@ final class AzureStorageBlobAdapter extends FilesystemAdapter
             new ManagedIdentityCredentialOptions(
                 authorityHost: $authorityHost ?? AzureAuthorityHosts::AZURE_PUBLIC_CLOUD,
                 clientId: $clientId,
+                httpClient: $httpClient,
             )
         );
     }

--- a/src/BlobLaravel/AzureStorageBlobDiskConfig.php
+++ b/src/BlobLaravel/AzureStorageBlobDiskConfig.php
@@ -31,7 +31,10 @@ final class AzureStorageBlobDiskConfig
      *     container: string,
      *     prefix?: string,
      *     root?: string,
-     *     is_public_container?: bool
+     *     is_public_container?: bool,
+     *     timeout?: int,
+     *     connect_timeout?: int,
+     *     verify_ssl?: bool
      * } $config
      */
     public static function validate(array &$config): void
@@ -53,6 +56,9 @@ final class AzureStorageBlobDiskConfig
         self::assertString($config, 'account_name');
         self::assertString($config, 'connection_string');
         self::assertBool($config, 'is_public_container');
+        self::assertInt($config, 'timeout');
+        self::assertInt($config, 'connect_timeout');
+        self::assertBool($config, 'verify_ssl');
     }
 
     /**
@@ -88,6 +94,24 @@ final class AzureStorageBlobDiskConfig
 
         if (! is_bool($config[$key])) {
             throw new \InvalidArgumentException("The [{$key}] must be a boolean in the disk configuration.");
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private static function assertInt(array $config, string $key, bool $required = false): void
+    {
+        if (! array_key_exists($key, $config) || $config[$key] === null) {
+            if ($required) {
+                throw new \InvalidArgumentException("The [{$key}] must be an integer in the disk configuration.");
+            }
+
+            return;
+        }
+
+        if (! is_int($config[$key])) {
+            throw new \InvalidArgumentException("The [{$key}] must be an integer in the disk configuration.");
         }
     }
 }

--- a/tests/BlobLaravel/AzureStorageBlobAdapterHttpOptionsTest.php
+++ b/tests/BlobLaravel/AzureStorageBlobAdapterHttpOptionsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AzureOss\Storage\Tests\BlobLaravel;
+
+use AzureOss\Storage\BlobLaravel\AzureStorageBlobAdapter;
+use AzureOss\Storage\BlobLaravel\AzureStorageBlobServiceProvider;
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class AzureStorageBlobAdapterHttpOptionsTest extends TestCase
+{
+    /**
+     * A well-formed (Azurite) connection string: the disk resolves without any
+     * network call, so these tests only exercise config validation and adapter
+     * wiring of the new HTTP options, not real Azure I/O.
+     */
+    private const CONNECTION_STRING = 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;';
+
+    protected function getPackageProviders($app): array
+    {
+        return [AzureStorageBlobServiceProvider::class];
+    }
+
+    #[Test]
+    public function it_resolves_the_disk_when_http_client_options_are_configured(): void
+    {
+        config(['filesystems.disks.azure' => [
+            'driver' => 'azure-storage-blob',
+            'connection_string' => self::CONNECTION_STRING,
+            'container' => 'noop',
+            'timeout' => 30,
+            'connect_timeout' => 10,
+            'verify_ssl' => false,
+        ]]);
+
+        self::assertInstanceOf(AzureStorageBlobAdapter::class, Storage::disk('azure'));
+    }
+
+    #[Test]
+    public function it_rejects_a_non_integer_timeout(): void
+    {
+        config(['filesystems.disks.azure' => [
+            'driver' => 'azure-storage-blob',
+            'connection_string' => self::CONNECTION_STRING,
+            'container' => 'noop',
+            'timeout' => '30',
+        ]]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('[timeout]');
+
+        Storage::disk('azure');
+    }
+
+    #[Test]
+    public function it_rejects_a_non_boolean_verify_ssl(): void
+    {
+        config(['filesystems.disks.azure' => [
+            'driver' => 'azure-storage-blob',
+            'connection_string' => self::CONNECTION_STRING,
+            'container' => 'noop',
+            'verify_ssl' => 'yes',
+        ]]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('[verify_ssl]');
+
+        Storage::disk('azure');
+    }
+}


### PR DESCRIPTION
## Why

With token-based credentials (Entra ID / client certificate / client secret / workload / managed identity), the Laravel disk builds the credential with default options. The credential then resolves its **auth HTTP client through PSR-18 discovery with no timeout**, so the Entra ID token request can hang indefinitely.

In a Laravel app on Heroku this surfaced as a recurring **H12 "Request timeout"**: every disk operation (temporary upload, validation `HEAD`, read) re-fetches the token synchronously, and a single slow/stalled call to `login.microsoftonline.com` blocked the web request until PHP-FPM killed it at 30s. There was no way to bound that call from the disk config.

The blob `BlobServiceClient` already accepts `HttpClientOptions`, but the Laravel adapter never exposed them, and they were never propagated to the token request.

## What

Adds three **optional, opt-in** keys to the `azure-storage-blob` disk config:

| key | type | maps to |
|---|---|---|
| `timeout` | int (seconds) | Guzzle `timeout` |
| `connect_timeout` | int (seconds) | Guzzle `connect_timeout` |
| `verify_ssl` | bool | Guzzle `verify` |

They are applied to:
1. the **Blob service client** via `BlobServiceClientOptions(HttpClientOptions)` (both the connection-string and token/endpoint paths);
2. the **token credential** — a Guzzle client built from the same options is passed as the `httpClient` on the credential options, so the Entra ID token request finally respects a timeout.

```php
// config/filesystems.php
'azure' => [
    'driver' => 'azure-storage-blob',
    'credential' => 'client_certificate',
    'endpoint' => env('AZURE_STORAGE_ENDPOINT'),
    'tenant_id' => env('AZURE_TENANT_ID'),
    'client_id' => env('AZURE_CLIENT_ID'),
    'client_certificate_path' => storage_path('azure.pem'),
    'container' => env('AZURE_STORAGE_CONTAINER'),

    'connect_timeout' => 10,
    'timeout' => 30,
    // 'verify_ssl' => true,
],
```

## Backwards compatibility

Fully opt-in. When none of the keys are set, `HttpClientOptions::toGuzzleHttpClientConfig()` is empty, **no custom client is injected** into the credential, and the `BlobServiceClientOptions` are equivalent to the defaults — behaviour is unchanged.

## Tests

`tests/BlobLaravel/AzureStorageBlobAdapterHttpOptionsTest.php`:
- the disk resolves when the HTTP options are configured (offline, via a well-formed Azurite connection string);
- a non-integer `timeout` and a non-boolean `verify_ssl` are rejected by config validation.

`vendor/bin/pint` and `vendor/bin/phpstan` (level 10 over `src/` + `tests/`) are green for the changed files.

> Note: token caching across requests (so the token isn't re-fetched on every operation) is intentionally left to the application layer; this PR only makes the HTTP behaviour configurable so the auth call can't hang. Happy to add docs on the docs site if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)