### PR TITLE
fix: cast Content-Length to string for Guzzle 7.11/8.0 compatibility

### DIFF
--- a/src/Blob/BlobClient.php
+++ b/src/Blob/BlobClient.php
@@ -232,7 +232,7 @@ final class BlobClient
             ->putAsync($this->uri, [
                 RequestOptions::HEADERS => array_filter([
                     'x-ms-blob-type' => 'BlockBlob',
-                    'Content-Length' => $content->getSize(),
+                    'Content-Length' => $content->getSize() === null ? null : (string) $content->getSize(),
                     ...$httpHeaders->toArray(),
                 ], fn ($value) => $value !== null),
                 RequestOptions::BODY => $content,

--- a/src/Blob/Specialized/BlockBlobClient.php
+++ b/src/Blob/Specialized/BlockBlobClient.php
@@ -62,7 +62,7 @@ final class BlockBlobClient
                 ],
                 RequestOptions::HEADERS => [
                     'Content-MD5' => HashHelper::serializeMd5($md5),
-                    'Content-Length' => $stream->getSize(),
+                    'Content-Length' => (string) $stream->getSize(),
                 ],
                 'body' => $content,
             ]);


### PR DESCRIPTION
## Problem

Guzzle **7.11.0** deprecated passing non-string scalars to documented request options — including an `int` for the `headers.Content-Length` option (to be rejected in Guzzle **8.0**):

```
Since guzzlehttp/guzzle 7.11: Passing int to request option "headers.Content-Length" is deprecated;
guzzlehttp/guzzle 8.0 requires string|non-empty-array<array-key, string>.
```

Two blob upload paths pass `StreamInterface::getSize()` (an `int`) directly as the `Content-Length` request-option header:

- `src/Blob/BlobClient.php` — `uploadViaPutBlobAsync()` (every single-shot blob upload)
- `src/Blob/Specialized/BlockBlobClient.php` — `stageBlockAsync()` (every staged block in large / parallel uploads)

On any app running Guzzle `>= 7.11`, this fires a deprecation on **every** upload. With SharedKey-signed requests — where `Content-Length` is set explicitly for the signature — it's effectively unavoidable, producing high-volume deprecation noise (we hit this as a recurring Sentry issue on a production app doing frequent blob uploads).

## Fix

Cast the value to `string` (`Content-Length` is a string header anyway). No behavioral change on Guzzle 7.x, forward-compatible with Guzzle 8.0, and arguably more type-correct for the request-options array.

- `BlobClient` — value sits inside `array_filter(..., fn ($v) => $v !== null)`, so the `null` branch is preserved to keep filtering out an unknown size:
  ```php
  'Content-Length' => $content->getSize() === null ? null : (string) $content->getSize(),
  ```
- `BlockBlobClient` — a staged block always has a known size:
  ```php
  'Content-Length' => (string) $stream->getSize(),
  ```

These are the only two `'Content-Length' =>` assignments under `src/`.

## Notes

Verified against a production app: with the cast applied, the Guzzle 7.11 deprecation no longer fires on uploads. `php -l` clean; happy to add a regression test if you can point me at the preferred way to assert request-option types (the deprecation is emitted at request-build time, before the HTTP call).
